### PR TITLE
Verify GitHub access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,32 @@ Or you can apply permissions to all repositories for one team:
 
     $ octo-keeper teams apply --org ninech 12345 pull
 
-Start the webhook server to receive github webhooks:
+### Github Webhook
 
+Start the webhook server to receive Github organization webhooks:
+
+    $ export OCTOKEEPER_GITHUB_SECRET=super-secret
     $ octo-keeper webhook start --config config.yml
 
-Now you can enter the following webhook at Github.com: https://hostname/
+Now you can enter the following webhook on Github.com (https://github.com/organizations/your_organization_name/settings/hooks):
+
+    http://hostname:4567
+
+Choose `application/json` as the content type.
+
+In the above example you will have to add the secret `super-secret`. You can run the webhook server without a shared secret, but that is not recommended.
 
 ## Docker
 
 Octo-Keeper can be run in its own Docker container. You can link the configuration file into the container as a volume.
 
+    # build the image from this repository. Or skip this line if you want to pull it from the registry.
+    $ docker build . -t ninech/octo-keeper
+
     $ docker run --name octo-keeper \
                  -p 4567:4567 \
                  -v $(pwd)/config.example.yml:/home/octo-keeper/config.yml \
+                 -e OCTOKEEPER_GITHUB_SECRET=super-secret \
                  -e OCTOKEEPER_ACCESS_TOKEN=secret-token \
                  ninech/octo-keeper
 
@@ -58,6 +71,11 @@ $ bin/octo-keeper webhook start
 $ http --json POST localhost:4567 < spec/fixtures/example-repository-create-event.json
 # With Curl
 $ curl -X POST http://localhost:4567/ -d @spec/fixtures/example-repository-create-event --header "Content-Type: application/json"
+
+# Using a Github secret
+$ export OCTOKEEPER_GITHUB_SECRET=super-secret
+$ bin/octo-keeper webhook start
+$ http --json POST localhost:4567 X-Hub-Signature:sha1=d1ee402dd2742b6646f564bffb5f5f7fe81742c3 < spec/fixtures/example-repository-create-event.json
 ```
 
 ## Contributing

--- a/lib/octo_keeper/commands/webhook.rb
+++ b/lib/octo_keeper/commands/webhook.rb
@@ -7,11 +7,15 @@ module OctoKeeper
       option :port, type: :numeric, default: 4567, banner: 'PORT', desc: 'The on which to listen for requests.'
       option :bind, type: :string, default: 'localhost', desc: 'The interface to listen on.'
       option :config, type: :string, default: '~/.octo-keeper.yml', desc: 'Path to the config file.'
+      option 'github-secret', type: :string,
+                              desc: 'A secret token to share with Github.com. Default: $OCTOKEEPER_GITHUB_TOKEN.'
       def start
         load_configuration
 
         port = OctoKeeper.config.port || options[:port]
         bind = OctoKeeper.config.bind || options[:bind]
+        OctoKeeper.config.github_secret ||= options['github-secret']
+
         OctoKeeper::WebhookApp.run! port: port, bind: bind
       end
 

--- a/lib/octo_keeper/configuration.rb
+++ b/lib/octo_keeper/configuration.rb
@@ -6,6 +6,7 @@ module OctoKeeper
   class Configuration
     attr_reader :port, :bind
     attr_reader :repositories
+    attr_writer :github_secret
 
     def self.load(path = 'config.yml')
       expanded_path = File.expand_path(path)
@@ -27,6 +28,10 @@ module OctoKeeper
 
     def default_repository_config
       @repositories['default'] || {}
+    end
+
+    def github_secret
+      @github_secret || ENV['OCTOKEEPER_GITHUB_SECRET']
     end
 
     private

--- a/lib/octo_keeper/version.rb
+++ b/lib/octo_keeper/version.rb
@@ -1,3 +1,3 @@
 module OctoKeeper
-  VERSION = "0.2.0".freeze
+  VERSION = "0.2.1".freeze
 end

--- a/lib/octo_keeper/webhook_app.rb
+++ b/lib/octo_keeper/webhook_app.rb
@@ -15,12 +15,15 @@ module OctoKeeper
       { error: 'Cannot parse payload. Invalid JSON.' }.to_json
     end
 
+    before %r{\/((?!ping).)*} do # all except /ping
+      verify_signature!(payload_body)
+    end
+
     get '/ping' do
       { pong: DateTime.now.rfc3339 }.to_json
     end
 
     post '/' do
-      verify_signature!(payload_body)
       return halt 400, { message: 'OctoKeeper cannot handle this event.' }.to_json unless parsed_body['repository']
 
       repository = Repository.new parsed_body['repository']

--- a/lib/octo_keeper/webhook_app.rb
+++ b/lib/octo_keeper/webhook_app.rb
@@ -9,10 +9,6 @@ module OctoKeeper
       enable :logging
     end
 
-    before do
-      # check for secret in header
-    end
-
     error JSON::ParserError do
       logger.error "Received unparsable JSON payload."
       status 500
@@ -24,13 +20,11 @@ module OctoKeeper
     end
 
     post '/' do
-      if parsed_body['repository']
-        repository = Repository.new parsed_body['repository']
-        logger.info %(Received "#{parsed_body['action']}" event for repository #{repository.full_name}.)
-      else
-        status 400
-        return { message: 'OctoKeeper cannot handle this event.' }.to_json
-      end
+      verify_signature!(payload_body)
+      return halt 400, { message: 'OctoKeeper cannot handle this event.' }.to_json unless parsed_body['repository']
+
+      repository = Repository.new parsed_body['repository']
+      logger.info %(Received "#{parsed_body['action']}" event for repository #{repository.full_name}.)
 
       handle_repository_created(repository) if parsed_body['action'] == 'created'
 
@@ -39,10 +33,14 @@ module OctoKeeper
 
     private
 
-    def parsed_body
-      return @parsed_body if @parsed_body
+    def payload_body
+      return @payload_body if @payload_body
       request.body.rewind
-      @parsed_body = JSON.parse(request.body.read)
+      @payload_body = request.body.read
+    end
+
+    def parsed_body
+      @parsed_body ||= JSON.parse(payload_body)
     end
 
     def handle_repository_created(repository)
@@ -57,6 +55,15 @@ module OctoKeeper
       logger.info "Added #{permission} permission for team #{team.slug} on #{repository.name}."
     rescue StandardError => e
       logger.error "Setting permissions for team #{team_slug} failed: #{e.message}"
+    end
+
+    def verify_signature!(payload_body)
+      secret = OctoKeeper.config.github_secret
+      return true unless secret
+
+      signature = 'sha1=' + OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha1'), secret, payload_body)
+      return if Rack::Utils.secure_compare(signature, request.env['HTTP_X_HUB_SIGNATURE'].to_s)
+      halt 403, { message: "Invalid access token!" }.to_json
     end
   end
 end


### PR DESCRIPTION
It is now possible to set a secret when configuring the Github webhook.
Octokeeper needs the environment variable `OCTOKEEPER_GITHUB_SECRET` set.